### PR TITLE
Amélioration des labels & descriptions

### DIFF
--- a/admin/app/content/casestudies.js
+++ b/admin/app/content/casestudies.js
@@ -1,9 +1,9 @@
 import { isNotIndex } from '../fields/is-not-index.js';
 import { draft } from '../fields/draft.js';
 import { date } from '../fields/date.js';
-import { description } from '../fields/description.js';
+import { description } from '../fields/page-description.js';
 import { featured_image } from '../fields/featured-image.js';
-import { title } from '../fields/title-required.js';
+import { title } from '../fields/page-title.js';
 import { hero } from '../fields/hero.js';
 import { blocks } from '../blocks/blocks.js';
 import { t } from '../i18n/translater.js';

--- a/admin/app/content/expertises.js
+++ b/admin/app/content/expertises.js
@@ -1,9 +1,9 @@
-import { isNotIndex } from '../fields/is-not-index.js';
-import { draft } from '../fields/draft.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
 import { body } from '../fields/body.js';
+import { draft } from '../fields/draft.js';
 import { featured_image } from '../fields/featured-image.js';
+import { isNotIndex } from '../fields/is-not-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { t } from '../i18n/translater.js';
 
 const expertises = {

--- a/admin/app/content/indexes.js
+++ b/admin/app/content/indexes.js
@@ -1,8 +1,8 @@
-import { isIndex } from '../fields/is-index.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
-import { hero } from '../fields/hero.js';
 import { blocks } from '../blocks/blocks.js';
+import { hero } from '../fields/hero.js';
+import { isIndex } from '../fields/is-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { t } from '../i18n/translater.js';
 
 const indexes = {

--- a/admin/app/content/pages.js
+++ b/admin/app/content/pages.js
@@ -1,11 +1,11 @@
-import { isPage } from '../fields/is-page.js';
-import { draft } from '../fields/draft.js';
-import { title } from '../fields/title-required.js';
-import { hero } from '../fields/hero.js';
-import { featured_image } from '../fields/featured-image.js';
-import { description } from '../fields/description.js';
-import { body } from '../fields/body.js';
 import { blocks } from '../blocks/blocks.js';
+import { body } from '../fields/body.js';
+import { draft } from '../fields/draft.js';
+import { featured_image } from '../fields/featured-image.js';
+import { hero } from '../fields/hero.js';
+import { isPage } from '../fields/is-page.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { t } from '../i18n/translater.js';
 
 const pages = {

--- a/admin/app/content/persons.js
+++ b/admin/app/content/persons.js
@@ -1,7 +1,7 @@
 import { isNotIndex } from '../fields/is-not-index.js';
 import { draft } from '../fields/draft.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
+import { title } from '../fields/page-title.js';
+import { description } from '../fields/page-description.js';
 import { featured_image } from '../fields/featured-image.js';
 import { contact } from '../fields/contact.js';
 import { body } from '../fields/body.js';

--- a/admin/app/content/places.js
+++ b/admin/app/content/places.js
@@ -1,12 +1,12 @@
-import { isNotIndex } from '../fields/is-not-index.js';
-import { draft } from '../fields/draft.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
-import { featured_image } from '../fields/featured-image.js';
-import { address } from '../fields/address.js';
-import { contact } from '../fields/contact.js';
-import { body } from '../fields/body.js';
 import { blocks } from '../blocks/blocks.js';
+import { address } from '../fields/address.js';
+import { body } from '../fields/body.js';
+import { contact } from '../fields/contact.js';
+import { draft } from '../fields/draft.js';
+import { featured_image } from '../fields/featured-image.js';
+import { isNotIndex } from '../fields/is-not-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { t } from '../i18n/translater.js';
 
 const places = {

--- a/admin/app/content/posts.js
+++ b/admin/app/content/posts.js
@@ -1,13 +1,13 @@
-import { isNotIndex } from '../fields/is-not-index.js';
-import { draft } from '../fields/draft.js';
-import { date } from '../fields/date.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
-import { featured_image } from '../fields/featured-image.js';
+import { authors } from '../fields/authors.js';
 import { body } from '../fields/body.js';
 import { categories } from '../fields/categories.js';
+import { date } from '../fields/date.js';
+import { draft } from '../fields/draft.js';
+import { featured_image } from '../fields/featured-image.js';
+import { isNotIndex } from '../fields/is-not-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { tags } from '../fields/tags.js';
-import { authors } from '../fields/authors.js';
 import { t } from '../i18n/translater.js';
 
 const posts = {

--- a/admin/app/content/products.js
+++ b/admin/app/content/products.js
@@ -1,14 +1,14 @@
-import { isNotIndex } from '../fields/is-not-index.js';
+import { body } from '../fields/body.js';
+import { date } from '../fields/date.js';
 import { draft } from '../fields/draft.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
+import { featured_image } from '../fields/featured-image.js';
+import { images } from '../fields/images.js';
+import { isNotIndex } from '../fields/is-not-index.js';
 import { offer } from '../fields/offer.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { products_categories } from '../fields/products_categories.js';
 import { products_tags } from '../fields/products_tags.js';
-import { date } from '../fields/date.js';
-import { featured_image } from '../fields/featured-image.js';
-import { body } from '../fields/body.js';
-import { images } from '../fields/images.js';
 import { t } from '../i18n/translater.js';
 
 const products = {

--- a/admin/app/content/projects.js
+++ b/admin/app/content/projects.js
@@ -1,14 +1,14 @@
-import { isNotIndex } from '../fields/is-not-index.js';
-import { draft } from '../fields/draft.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
-import { date } from '../fields/date.js';
-import { projects_types } from '../fields/projects_types.js';
-import { projects_tags } from '../fields/projects_tags.js';
-import { featured_image } from '../fields/featured-image.js';
-import { datas } from '../fields/datas.js';
 import { body } from '../fields/body.js';
+import { datas } from '../fields/datas.js';
+import { date } from '../fields/date.js';
+import { draft } from '../fields/draft.js';
+import { featured_image } from '../fields/featured-image.js';
 import { images } from '../fields/images.js';
+import { isNotIndex } from '../fields/is-not-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
+import { projects_tags } from '../fields/projects_tags.js';
+import { projects_types } from '../fields/projects_types.js';
 import { t } from '../i18n/translater.js';
 
 const projects = {

--- a/admin/app/content/publications.js
+++ b/admin/app/content/publications.js
@@ -1,13 +1,13 @@
-import { isNotIndex } from '../fields/is-not-index.js';
-import { draft } from '../fields/draft.js';
+import { body } from '../fields/body.js';
 import { date } from '../fields/date.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
-import { press } from '../fields/press.js';
-import { publications_persons } from '../fields/publications_persons.js';
+import { draft } from '../fields/draft.js';
 import { featured_image } from '../fields/featured-image.js';
 import { images } from '../fields/images.js';
-import { body } from '../fields/body.js';
+import { isNotIndex } from '../fields/is-not-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
+import { press } from '../fields/press.js';
+import { publications_persons } from '../fields/publications_persons.js';
 import { t } from '../i18n/translater.js';
 
 const publications = {

--- a/admin/app/content/realestates.js
+++ b/admin/app/content/realestates.js
@@ -1,20 +1,19 @@
-import { isNotIndex } from '../fields/is-not-index.js';
-import { draft } from '../fields/draft.js';
-import { date } from '../fields/date.js';
-import { reference } from '../fields/reference.js';
-import { title } from '../fields/title-required.js';
-import { description } from '../fields/description.js';
-import { realestates_persons } from '../fields/realestates_persons.js';
-import { realestates_categories } from '../fields/realestates_categories.js';
-import { offer } from '../fields/offer.js';
-import { informations } from '../fields/realestates-informations.js';
 import { address } from '../fields/address.js';
-import { keyfeatures } from '../fields/keyfeatures.js';
+import { body } from '../fields/body.js';
+import { date } from '../fields/date.js';
 import { diagnostic } from '../fields/diagnostic.js';
-import { documents } from '../fields/documents.js';
+import { draft } from '../fields/draft.js';
 import { featured_image } from '../fields/featured-image.js';
 import { gallery } from '../fields/gallery.js';
-import { body } from '../fields/body.js';
+import { isNotIndex } from '../fields/is-not-index.js';
+import { keyfeatures } from '../fields/keyfeatures.js';
+import { offer } from '../fields/offer.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
+import { informations } from '../fields/realestates-informations.js';
+import { realestates_categories } from '../fields/realestates_categories.js';
+import { realestates_persons } from '../fields/realestates_persons.js';
+import { reference } from '../fields/reference.js';
 import { t } from '../i18n/translater.js';
 
 const realestates = {

--- a/admin/app/content/services.js
+++ b/admin/app/content/services.js
@@ -1,11 +1,11 @@
 import { body } from '../fields/body.js';
-import { description } from '../fields/description.js';
 import { draft } from '../fields/draft.js';
 import { featured_image } from '../fields/featured-image.js';
 import { isNotIndex } from '../fields/is-not-index.js';
+import { description } from '../fields/page-description.js';
+import { title } from '../fields/page-title.js';
 import { services_categories } from '../fields/services_categories.js';
 import { services_persons } from '../fields/services_persons.js';
-import { title } from '../fields/title-required.js';
 import { t } from '../i18n/translater.js';
 
 const services = {

--- a/admin/app/fields/featured-image.js
+++ b/admin/app/fields/featured-image.js
@@ -5,10 +5,11 @@ import { t } from '../i18n/translater.js';
 
 export const featured_image = {
   name: 'image',
-  label: t.fields.featured_image,
+  label: t.fields.featured_image.label,
+  hint: t.fields.featured_image.hint,
   widget: 'object',
   required: false,
   i18n: true,
-  collapsed: false,
+  collapsed: true,
   fields: [image_src, image_alt, credit]
 };

--- a/admin/app/fields/page-description.js
+++ b/admin/app/fields/page-description.js
@@ -1,0 +1,10 @@
+import { t } from '../i18n/translater.js';
+
+export const description = {
+  name: 'description',
+  label: t.fields.page_description.label,
+  hint: t.fields.page_description.hint,
+  widget: 'text',
+  required: false,
+  i18n: true
+};

--- a/admin/app/fields/page-title.js
+++ b/admin/app/fields/page-title.js
@@ -1,0 +1,10 @@
+import { t } from '../i18n/translater.js';
+
+export const title = {
+  name: 'title',
+  label: t.fields.page_title.label,
+  hint: t.fields.page_title.hint,
+  widget: 'string',
+  required: true,
+  i18n: true
+};

--- a/admin/app/i18n/en/fields.js
+++ b/admin/app/i18n/en/fields.js
@@ -138,7 +138,10 @@ export const fields = {
   email: 'Email',
   embed: 'Embed',
   expertises_items: 'Expertises',
-  featured_image: 'Featured image',
+  featured_image: {
+    label: 'Featured image',
+    hint: 'Displayed in search results, and in SMS/Messages/Social networks preview'
+  },
   figure: 'Image with legend',
   files: 'Files',
   gallery: 'Image gallery',
@@ -154,7 +157,7 @@ export const fields = {
   half: 'Half size?',
   heading: 'Heading',
   hero: {
-    label: 'Hero',
+    label: 'Top page section',
     fields: {
       image: {
         label: 'Image',
@@ -258,6 +261,14 @@ export const fields = {
     }
   },
   pages: 'Pages',
+  page_description: {
+    label: 'Description',
+    hint: 'Displayed in search results, and in SMS/Messages/Social networks preview'
+  },
+  page_title: {
+    label: 'Title of the page',
+    hint: 'Displayed in tabs, search results, and in SMS/Messages/Social networks preview'
+  },
   pdf: {
     label: 'PDF',
     hint: 'Compress PDF before sending: https://www.adobe.com/fr/acrobat/online/compress-pdf.html'

--- a/admin/app/i18n/fr/fields.js
+++ b/admin/app/i18n/fr/fields.js
@@ -138,7 +138,10 @@ export const fields = {
   email: 'Email',
   embed: 'Embed',
   expertises_items: 'Expertises',
-  featured_image: 'Image mise en avant',
+  featured_image: {
+    label: 'Image mise en avant',
+    hint: 'Affichée dans les résultats de recherche et dans la prévisualition SMS/Messages/Réseaux sociaux'
+  },
   figure: 'Image avec légende',
   gallery: 'Galerie d’images',
   grid: {
@@ -153,7 +156,7 @@ export const fields = {
   half: 'Demi-taille ?',
   heading: 'En-tête',
   hero: {
-    label: 'Hero',
+    label: 'Section de haut de page',
     fields: {
       image: {
         label: 'Image',
@@ -255,6 +258,14 @@ export const fields = {
       end: 'à droite',
       center: 'au centre'
     }
+  },
+  page_description: {
+    label: 'Description',
+    hint: 'Affichée dans les résultats de recherche et dans la prévisualisation SMS/Messages/Réseaux sociaux'
+  },
+  page_title: {
+    label: 'Titre de la page',
+    hint: 'Affiché dans les onglets, dans les résultats de recherche et dans la prévisualition SMS/Messages/Réseaux sociaux'
   },
   pages: 'Pages',
   pdf: {


### PR DESCRIPTION
# Contexte
Vu que le passage à un autre admin est une tâche complexe et chronophage, voici une amélioration de l'admin decap en attendant

# Problèmes
- Un de mes clients ne comprend pas à quoi correspondent "Titre", "Description" et "Image mise en avant"
- De même, le block "hero" n'est pas très explicite

# Solution proposée
Apporter plus d'explications via des "hint" et des labels plus explicites.
## En détail 
- Création de deux fields (page-title, page-description) spécifiques aux pages, utilisation de ces deux pour les collection qui génèrent des pages (pas pour les tags, categories etc)
- Ajout de hint 
